### PR TITLE
Remove shadow dom from css selectors

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -16,7 +16,7 @@ atom-text-editor[mini] {
   padding-left: @ui-padding/2;
 
   &,
-  &::shadow {
+  &.editor {
     .placeholder-text {
       color: @text-color-subtle;
     }
@@ -30,7 +30,7 @@ atom-text-editor[mini] {
   }
 
   &.is-focused,
-  &.is-focused::shadow {
+  &.is-focused .editor {
     .focus();
     background-color: @input-background-color-focus;
     .selection .region {

--- a/styles/packages.less
+++ b/styles/packages.less
@@ -121,7 +121,7 @@
     background-clip: padding-box;
   }
 
-  atom-text-editor::shadow {
+  atom-text-editor .editor {
     .line.cursor-line {
       background-color: transparent;
     }


### PR DESCRIPTION
I'm not a CSS nor a less expert, but I did this to remove deprecation warnings from Atom.